### PR TITLE
fix bug in scroll animation duration

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -64,6 +64,11 @@
 					e.stopPropagation();
 					$(".scrollbar_scroll").scroller("scroll", $(this).attr("href"));
 				});
+                $(".scroll_animate").on("click", function(e) {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    $(".scrollbar_scroll").scroller("scroll", 300, 500);
+                });
 			});
 		</script>
 	</head>
@@ -169,6 +174,7 @@
 					<a href="#" class="scroll_top button small">Scroll to "0px"</a>
 					<a href="#" class="scroll_mid button small">Scroll to "200px"</a>
 					<a href="#scroll_target" class="scroll_target button small">Scroll to "#scroll_target"</a>
+                    <a href="#" class="scroll_animate button small">Animate scroll to "300px" in 500ms</a>
 				</div>
 				<div class="scrollbar_scroll scrollbar">
 					<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla porta aliquet gravida. Aenean pulvinar blandit orci vel fermentum. Phasellus viverra pulvinar viverra. Quisque et sagittis ante. Nulla sem neque, fermentum at laoreet vel, rhoncus sit amet nisl. Donec consectetur urna ac massa placerat ac pharetra sem mollis. Integer nibh urna, placerat vel placerat in, tempor at nisi. Aenean rutrum, enim sit amet rutrum fermentum, magna justo volutpat massa, lacinia adipiscing nisl magna eget nibh. In auctor, nibh eget faucibus tristique, arcu turpis molestie orci, placerat suscipit diam nibh et erat. Curabitur tempus lectus quis odio ornare porta.</p>

--- a/jquery.fs.scroller.css
+++ b/jquery.fs.scroller.css
@@ -1,5 +1,5 @@
 /* 
- * Scroller v3.0.3 - 2014-03-26 
+ * Scroller v3.0.3 - 2014-04-07 
  * A jQuery plugin for replacing default browser scrollbars. Part of the Formstone Library. 
  * http://formstone.it/scroller/ 
  * 

--- a/jquery.fs.scroller.js
+++ b/jquery.fs.scroller.js
@@ -1,5 +1,5 @@
 /* 
- * Scroller v3.0.3 - 2014-03-26 
+ * Scroller v3.0.3 - 2014-04-07 
  * A jQuery plugin for replacing default browser scrollbars. Part of the Formstone Library. 
  * http://formstone.it/scroller/ 
  * 
@@ -74,10 +74,10 @@
 		 * @param duration [int] <null> "Optional scroll duration"
 		 * @example $.scroller("scroll", pos, duration);
 		 */
-		scroll: function(pos, duration) {
+		scroll: function(pos, dur) {
 			return $(this).each(function(i) {
 				var data = $(this).data("scroller"),
-	                duration = duration || options.duration;
+	                duration = dur || options.duration;
 
 				if (typeof pos !== "number") {
 					var $el = $(pos);

--- a/jquery.fs.scroller.min.js
+++ b/jquery.fs.scroller.min.js
@@ -1,5 +1,5 @@
 /* 
- * Scroller v3.0.3 - 2014-03-26 
+ * Scroller v3.0.3 - 2014-04-07 
  * A jQuery plugin for replacing default browser scrollbars. Part of the Formstone Library. 
  * http://formstone.it/scroller/ 
  * 


### PR DESCRIPTION
On line 80 of ‘scroll’ method, duration was overwriting the passed
value when the variable was instantiated.  Because it was null,
duration would always fall back to the default duration even if a
duration was passed.

Fix: Rename the passed duration variable name on line 77 so it doesn’t
get overwritten when ‘duration’ is instantiated in the jQuery loop on
line 80.
